### PR TITLE
fix: add missing ResponsePagePath for ErrorCode 501 configuration

### DIFF
--- a/react-cors-spa-stack.yaml
+++ b/react-cors-spa-stack.yaml
@@ -181,6 +181,7 @@ Resources:
             ResponsePagePath: /index.html
           - ErrorCode: 501
             ResponseCode: 501
+            ResponsePagePath: /index.html
             ErrorCachingMinTTL: 0
         PriceClass: PriceClass_All
         Logging:


### PR DESCRIPTION
*Issue #19*

*Description of changes:*
In the configuration for ErrorCode: 501, the ResponseCode was specified but the ResponsePagePath was missing.

According to AWS CloudFront requirements, both ResponseCode and ResponsePagePath must either be specified together or omitted together. This mismatch caused deployment failures when using CloudFormation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
